### PR TITLE
Fixed bug in writeFile() at gpio_test.cpp, which prevented the data to be written to the file

### DIFF
--- a/examples/gpio/gpio_test.cpp
+++ b/examples/gpio/gpio_test.cpp
@@ -104,7 +104,7 @@ void writeFile(int fileID, int value)
 {
   char buffer[4];  // A place to build our four-byte string.
   memset((void *)buffer, 0, sizeof(buffer)); // clear the buffer out.
-  sprintf(buffer, "%c", value);
+  sprintf(buffer, "%d", value);
   lseek(fileID, 0, SEEK_SET);   // Make sure we're at the top of the file!
   write(fileID, buffer, sizeof(buffer));
 }


### PR DESCRIPTION
The `writeFile()` function in gpio_test.cpp has a bug which prevents the program to write the data to the gpio file. In line 107 the `sprintf()` function writes out chars (`%c`), but it should write ints (`%d`). This is the way that is done by the pcDuino people in their [c_environment](https://github.com/pcduino/c_environment/blob/master/hardware/arduino/cores/arduino/wiring_digital.c) library. Here is the fixed `writeFile()`:

```
103 void writeFile(int fileID, int value)
104 {
105     char buffer[4];  // A place to build our four-byte string.
106     memset((void *)buffer, 0, sizeof(buffer)); // clear the buffer out.
107     sprintf(buffer, "%d", value);
108     lseek(fileID, 0, SEEK_SET);   // Make sure we're at the top of the file!
109     write(fileID, buffer, sizeof(buffer));
110 }
```
